### PR TITLE
Fix f-string backslash issue in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -901,7 +901,7 @@ class UiForm(QMainWindow):
 
             label = QLabel()
             label.setTextFormat(Qt.RichText)
-            label.setText(f'{field["label"]}: {"<span style=\"color:red\">*</span>" if is_required else ""}')
+            label.setText(f'{field["label"]}: ' + ('<span style="color:red">*</span>' if is_required else ''))
 
             widget = None
 


### PR DESCRIPTION
Fixes #2.

Replaced line 904 in `main.py` with:
label.setText(f'{field["label"]}: ' + ('<span style="color:red">*</span>' if is_required else ''))

This removes backslashes inside the f-string and works with Python 3.10.